### PR TITLE
注文時の連打による多数送信回避

### DIFF
--- a/templates/confirm.html
+++ b/templates/confirm.html
@@ -49,3 +49,15 @@
     </form>
   </div>
 {%- endblock %}
+
+{% block javascript %}
+  <script type="text/javascript">
+  //送信ボタンを押した際に送信ボタンを無効化する（連打による多数送信回避）
+  $(function(){
+    $('[type="submit"]').click(function(){
+      $(this).prop('disabled',true);//ボタンを無効化する
+      $(this).closest('form').submit();//フォームを送信する
+    });
+  });
+  </script>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -52,6 +52,7 @@
     <!-- Javascript -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-u1OknCvxWvY5kfmNBILK2hRnQC3Pr17a+RTT6rIHI7NnikvbZlHgTPOOmMi466C8" crossorigin="anonymous"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/main.js') }}"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     {% block javascript %}{% endblock %}
   </body>
 


### PR DESCRIPTION
## 変更の概要

* 注文時の連打による多数送信回避

## なぜこの変更をするのか

* 同じものが何回も注文されるのを防ぐため

## やったこと

* なし

## 変更内容

* layout.htmlにjquery/3.4.1が書いないので書きました

## 課題

* なし

## 備考

* jsでボタンを無効化だけだと/resultにポストできないみたいなのでその後ろにフォーム送信処理入れたらできました。