### PR TITLE
Feature/order_responsive:レスポンシブに対応させる

### DIFF
--- a/static/css/orders.css
+++ b/static/css/orders.css
@@ -7,3 +7,9 @@ input {
   border: none;
   outline: none;
 }
+.box{
+  text-align: center;
+}
+input {
+  width: 35px;
+}

--- a/static/js/orders.js
+++ b/static/js/orders.js
@@ -118,6 +118,7 @@ $("#salt_down").click(function () {
     $("#salt_down").prop("disabled", true);
   }
   $("#result").html(salt_num + catsup_num + cheese_num + butter_num);
+  $("#result_money").html(200 * (salt_num + catsup_num + cheese_num + butter_num));
 });
 
 $("#salt_up").click(function () {
@@ -128,6 +129,7 @@ $("#salt_up").click(function () {
     $("#salt_up").prop("disabled", true);
   }
   $("#result").html(salt_num + catsup_num + cheese_num + butter_num);
+  $("#result_money").html(200 * (salt_num + catsup_num + cheese_num + butter_num));
 });
 
 $("#catsup_down").click(function () {
@@ -138,6 +140,7 @@ $("#catsup_down").click(function () {
     $("#catsup_down").prop("disabled", true);
   }
   $("#result").html(salt_num + catsup_num + cheese_num + butter_num);
+  $("#result_money").html(200 * (salt_num + catsup_num + cheese_num + butter_num));
 });
 
 $("#catsup_up").click(function () {
@@ -148,6 +151,7 @@ $("#catsup_up").click(function () {
     $("#catsup_up").prop("disabled", true);
   }
   $("#result").html(salt_num + catsup_num + cheese_num + butter_num);
+  $("#result_money").html(200 * (salt_num + catsup_num + cheese_num + butter_num));
 });
 
 $("#cheese_down").click(function () {
@@ -158,6 +162,7 @@ $("#cheese_down").click(function () {
     $("#cheese_down").prop("disabled", true);
   }
   $("#result").html(salt_num + catsup_num + cheese_num + butter_num);
+  $("#result_money").html(200 * (salt_num + catsup_num + cheese_num + butter_num));
 });
 
 $("#cheese_up").click(function () {
@@ -168,6 +173,7 @@ $("#cheese_up").click(function () {
     $("#cheese_up").prop("disabled", true);
   }
   $("#result").html(salt_num + catsup_num + cheese_num + butter_num);
+  $("#result_money").html(200 * (salt_num + catsup_num + cheese_num + butter_num));
 });
 
 $("#butter_down").click(function () {
@@ -178,6 +184,7 @@ $("#butter_down").click(function () {
     $("#butter_down").prop("disabled", true);
   }
   $("#result").html(salt_num + catsup_num + cheese_num + butter_num);
+  $("#result_money").html(200 * (salt_num + catsup_num + cheese_num + butter_num));
 });
 
 $("#butter_up").click(function () {
@@ -188,4 +195,5 @@ $("#butter_up").click(function () {
     $("#butter_up").prop("disabled", true);
   }
   $("#result").html(salt_num + catsup_num + cheese_num + butter_num);
+  $("#result_money").html(200 * (salt_num + catsup_num + cheese_num + butter_num));
 });

--- a/templates/order.html
+++ b/templates/order.html
@@ -7,67 +7,110 @@
 {% endblock %}
 
 {%- block content %}
-  <p>全品２００円です！</p>
   {# inputタグのdisabledの挙動が怪しい場合、readonly属性に変更してみてください #}
   <form action="/confirm" method="post">
-    <div class="row justify-content-center">
-      <div class="card text-center menu mb-3 me-2 pb-2" style="width: 10rem;">
-        <p>塩</p>
-        <div class="spin">
-          <button id="salt_down" class="spin-minus rounded-circle" type="button" disabled="disabled">
-            －
-          </button>
-          <input id="salt" name="salt" type="number" class="spin-input text-center" min="0" max="3" step="1" value="0" readonly="readonly">
-          <button id="salt_up" class="spin-plus rounded-circle" type="button">
-            ＋
-          </button>
+    <div class="container">
+      <div class="row">
+        <div class="text-center mx-auto">
+          <p class="fw-bold mt-4">全品２００円です！</p>
         </div>
       </div>
-      <div class="card text-center menu mb-3 ms-2 pb-2" style="width: 10rem;">
-        <p>ケチャップ</p>
-        <div class="spin">
-          <button id="catsup_down" class="spin-minus rounded-circle" type="button" disabled="disabled">
-            －
-          </button>
-          <input id="catsup" name="ketchup" type="number" class="spin-input text-center" min="0" max="3" step="1" value="0" readonly="readonly">
-          <button id="catsup_up" class="spin-plus rounded-circle" type="button">
-            ＋
-          </button>
+      <div class="py-3 p-lg-5">
+        <div class="row mx-auto" style="max-width: 900px;">
+          <div class="col mb-3">
+            <div class="card ">
+              <div class="card-body">
+                <p class="fw-bold card-title text-center">塩
+                </p>
+                <div class="spin box">
+                  <button id="salt_down" class="spin-minus rounded-circle" type="button" disabled="disabled">
+                    －
+                  </button>
+                  <input id="salt" name="salt" type="text" class="spin-input text-center px-0" min="0" max="3" step="1" value="0" readonly="readonly">
+                  <button id="salt_up" class="spin-plus rounded-circle" type="button">
+                    ＋
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="col mb-3">
+            <div class="card ">
+              <div class="card-body">
+                <p class="fw-bold card-title text-center">ケチャップ
+                </p>
+                <div class="spin box">
+                  <button id="catsup_down" class="spin-minus rounded-circle" type="button" disabled="disabled">
+                    －
+                  </button>
+                  <input id="catsup" name="ketchup" type="text" class="spin-input text-center px-0" min="0" max="3" step="1" value="0" readonly="readonly">
+                  <button id="catsup_up" class="spin-plus rounded-circle" type="button">
+                    ＋
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="w-100"></div>
+          <div class="col mb-4">
+            <div class="card ">
+              <div class="card-body">
+                <p class="fw-bold card-title text-center">三種のチーズ
+                </p>
+                <div class="spin box">
+                  <button id="cheese_down" class="spin-minus rounded-circle" type="button" disabled="disabled">
+                    －
+                  </button>
+                  <input id="cheese" name="cheese" type="text" class="spin-input text-center px-0" min="0" max="3" step="1" value="0" readonly="readonly">
+                  <button id="cheese_up" class="spin-plus rounded-circle" type="button">
+                    ＋
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="col mb-4">
+            <div class="card ">
+              <div class="card-body">
+                <p class="fw-bold card-title text-center">バター醤油
+                </p>
+                <div class="spin box">
+                  <button id="butter_down" class="spin-minus rounded-circle" type="button" disabled="disabled">
+                    －
+                  </button>
+                  <input id="butter" name="butter" type="text" class="spin-input text-center px-0" min="0" max="3" step="1" value="0" readonly="readonly">
+                  <button id="butter_up" class="spin-plus rounded-circle" type="button">
+                    ＋
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="mt-4 container-fluid">
+            <div class="row">
+              <div class="col-sm-1 col-md-2 col-4">
+                <div class="text-end">
+                合計金額￥
+                </div>
+              </div>
+              <div class="col-sm-6 col-md-8 col-3">
+                <div id="result_money" class="text-start result">
+                  0
+                </div>
+              </div>
+              <div class="col-sm-5 col-md-2 col-5">
+                <button id="order_confirm" type="button" class="btn confirm btn-warning" disabled="disabled">
+                  注文確認
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-    <div class="row  justify-content-center">
-      <div class="card text-center menu me-2 pb-2" style="width: 10rem;">
-        <p>三種のチーズ</p>
-        <div class="spin">
-          <button id="cheese_down" class="spin-minus rounded-circle" type="button" disabled="disabled">
-            －
-          </button>
-          <input id="cheese" name="cheese" type="number" class="spin-input text-center" min="0" max="3" step="1" value="0" readonly="readonly">
-          <button id="cheese_up" class="spin-plus rounded-circle" type="button">
-            ＋
-          </button>
-        </div>
-      </div>
-      <div class="card text-center menu ms-2 pb-2" style="width: 10rem;">
-        <p>バター醤油</p>
-        <div class="spin">
-          <button id="butter_down" class="spin-minus rounded-circle" type="button" disabled="disabled">
-            －
-          </button>
-          <input id="butter" name="butter" type="number" class="spin-input text-center" min="0" max="3" step="1" value="0" readonly="readonly">
-          <button id="butter_up" class="spin-plus rounded-circle" type="button">
-            ＋
-          </button>
-        </div>
-      </div>
-    </div>
-    <button id="order_confirm" class="confirm" disabled="disabled">
-      注文確認
-    </button>
   </form>
 
-  <div id="result" class="result">
+  <div id="result" class="result" style="display: none;">
     0
   </div>
 

--- a/templates/order.html
+++ b/templates/order.html
@@ -99,7 +99,7 @@
                 </div>
               </div>
               <div class="col-sm-5 col-md-2 col-5">
-                <button id="order_confirm" type="button" class="btn confirm btn-warning" disabled="disabled">
+                <button id="order_confirm" class="btn confirm btn-warning" disabled="disabled">
                   注文確認
                 </button>
               </div>


### PR DESCRIPTION
## 関連

- #22 
- #36 

## 変更の概要

* orderページをレスポンシブに対応させる

## なぜこの変更をするのか

* スマホの画面サイズによってレイアウトが崩れてしまうのを防ぐため

## やったこと

* [x] input type="number" から input type="text"に変更
* [x] 合計金額表示
* [x] レイアウト変更

## 変更内容

* input type="number" から input type="text"に変更
* 合計金額表示
* レイアウト変更

## 備考

* 総数(113)を消していいかわからなかったのでstyle="display: none;"をつけときました。
