### PR TITLE
add:注文の合計数をBootstrapのバッジを利用してデザイン

### DIFF
--- a/templates/order.html
+++ b/templates/order.html
@@ -90,7 +90,7 @@
             <div class="row">
               <div class="col-sm-1 col-md-2 col-4">
                 <div class="text-end">
-                合計金額￥
+                  合計金額￥
                 </div>
               </div>
               <div class="col-sm-6 col-md-8 col-3">
@@ -99,8 +99,14 @@
                 </div>
               </div>
               <div class="col-sm-5 col-md-2 col-5">
-                <button id="order_confirm" class="btn confirm btn-warning" disabled="disabled">
+                <button id="order_confirm" class="btn confirm btn-warning position-relative" disabled="disabled">
                   注文確認
+                  <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-danger">
+                    <div id="result" class="result">
+                      0
+                    </div>
+                    <span class="visually-hidden">個数</span>
+                  </span>
                 </button>
               </div>
             </div>
@@ -109,10 +115,6 @@
       </div>
     </div>
   </form>
-
-  <div id="result" class="result" style="display: none;">
-    0
-  </div>
 
 {%- endblock %}
 


### PR DESCRIPTION
## 関連

- #36 

## 変更の概要

*  注文の合計数をBootstrapのバッジを利用してデザイン

## なぜこの変更をするのか

* 見やすくなる

## やったこと

* [x] 注文の合計数をBootstrapのバッジを利用してデザイン

## 変更内容

*  注文の合計数をBootstrapのバッジを利用してデザイン

## 課題

* なし

## 備考

* 特になし