### PR TITLE
iPhoneで注文画面でダブルタップした時拡大しないようにした

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -9,3 +9,6 @@ a:active {
   color: black;
   text-decoration: none; /* 下線を無効化 */
 }
+html {
+  touch-action: manipulation;
+}


### PR DESCRIPTION
## 関連

- #41 

## 変更の概要

* iPhoneで注文画面でダブルタップした時拡大してしまうので対策

## なぜこの変更をするのか

* なし

## やったこと

* [x] iPhoneで注文画面でダブルタップした時拡大してしまうので対策を考える
* [ ] order.htmlのボタンを修正する

## 変更内容

* style.cssを変更

## 課題

* なし  

## 備考

* なし