### PR TITLE
orderページの注文確認のボタンをconfirmページと同じにしました

### DIFF
--- a/static/css/orders.css
+++ b/static/css/orders.css
@@ -13,3 +13,13 @@ input {
 input {
   width: 35px;
 }
+
+
+#test {
+  position: absolute;
+  bottom: 100px;
+  margin: 0 auto;
+  left: 0;
+  right: 0;
+  width: calc(100vw * 0.9);
+}

--- a/static/css/orders.css
+++ b/static/css/orders.css
@@ -15,7 +15,7 @@ input {
 }
 
 
-#test {
+#order_btn {
   position: absolute;
   bottom: 100px;
   margin: 0 auto;

--- a/templates/confirm.html
+++ b/templates/confirm.html
@@ -25,7 +25,7 @@
                     {% endif %}
                     {% if ketchup != 0 %}
                       <tr>
-                        <td>ケチャップ</td>
+                        <td>カレー</td>
                         <td class="text-end">x{{ketchup}}</td>
                       </tr>
                     {% endif %}

--- a/templates/order.html
+++ b/templates/order.html
@@ -102,7 +102,7 @@
           </div>
         </div>
       </div>
-      <div class="row justify-content-around" id="test">
+      <div class="row justify-content-around" id="order_btn">
         <a class="btn btn-secondary text-white col-4" href="order">キャンセル</a>
         <button id="order_confirm" type="submit" class="btn btn-primary confirm position-relative col-4" disabled="disabled">注文確認
           <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-danger">

--- a/templates/order.html
+++ b/templates/order.html
@@ -37,7 +37,7 @@
           <div class="col mb-3">
             <div class="card ">
               <div class="card-body">
-                <p class="fw-bold card-title text-center">ケチャップ
+                <p class="fw-bold card-title text-center">カレー
                 </p>
                 <div class="spin box">
                   <button id="catsup_down" class="spin-minus rounded-circle" type="button" disabled="disabled">
@@ -98,20 +98,20 @@
                   0
                 </div>
               </div>
-              <div class="col-sm-5 col-md-2 col-5">
-                <button id="order_confirm" class="btn confirm btn-warning position-relative" disabled="disabled">
-                  注文確認
-                  <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-danger">
-                    <div id="result" class="result">
-                      0
-                    </div>
-                    <span class="visually-hidden">個数</span>
-                  </span>
-                </button>
-              </div>
             </div>
           </div>
         </div>
+      </div>
+      <div class="row justify-content-around" id="test">
+        <a class="btn btn-secondary text-white col-4" href="order">キャンセル</a>
+        <button id="order_confirm" type="submit" class="btn btn-primary confirm position-relative col-4" disabled="disabled">注文確認
+          <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill text-bg-danger">
+            <div id="result" class="result">
+              0
+            </div>
+            <span class="visually-hidden">個数</span>
+          </span>
+        </button>
       </div>
     </div>
   </form>


### PR DESCRIPTION
## 関連

- #40

## 変更の概要

* 注文確認ボタンをconfirm.htmlの注文ボタンと同じ場所に配置する

## なぜこの変更をするのか

* 統一をはかるため

## やったこと

* [x] 注文確認ボタンをconfirm.htmlの注文ボタンと同じ場所に配置する
* [x] ケチャップからカレーにしました。 

## 変更内容

* なし

## 課題

*なし

## 備考

* ケチャップからカレーにしました。
